### PR TITLE
Add support for types, segments, scopes

### DIFF
--- a/tdinfo_parser.py
+++ b/tdinfo_parser.py
@@ -3,6 +3,7 @@ import ida_kernwin
 import ida_nalt
 import ida_name
 import ida_segment
+import idc
 
 ida_idaapi.require('tdinfo_structs')
 
@@ -64,6 +65,7 @@ def apply_tdinfo_symbols():
     for symbol in parsed_exe_file.symbol_records:
         try:
             _apply_tdinfo_symbol(image_base, parsed_exe_file.name_pool, symbol)
+            _apply_tdinfo_type(image_base, parsed_exe_file, symbol)
             applied_symbols_count += 1
         except TdinfoParserSymbolAlreadyAppliedException:
             already_existing_symbols_count += 1
@@ -75,3 +77,113 @@ def apply_tdinfo_symbols():
     print('{} identical symbols already existed, {} new symbols were applied.'.format(
         already_existing_symbols_count,
         applied_symbols_count))
+
+    for segment in parsed_exe_file.segment_records:
+        _apply_tdinfo_segment(image_base, parsed_exe_file, segment)
+        _apply_tdinfo_scopes(image_base, parsed_exe_file, segment)
+
+
+def _apply_tdinfo_type(image_base, parsed_exe_file, symbol):
+    if (symbol.bitfield.symbol_class != tdinfo_structs.SymbolClass.STATIC.name or
+        symbol.type == 0):
+        return
+
+    symbol_ea = image_base + symbol.segment * 0x10 + symbol.offset
+    symbol_name = str(parsed_exe_file.name_pool[symbol.index - 1])
+
+    type = parsed_exe_file.type_records[symbol.type - 1]
+    _apply_tdinfo_type_rec(symbol_ea, symbol_name, parsed_exe_file, type)
+
+
+def _apply_tdinfo_type_rec(symbol_ea, symbol_name, parsed_exe_file, type):
+    if (type.id == tdinfo_structs.TypeId.SCHAR.name or
+        type.id == tdinfo_structs.TypeId.UCHAR.name):
+        idc.create_byte(symbol_ea)
+    elif (type.id == tdinfo_structs.TypeId.SINT.name or
+          type.id == tdinfo_structs.TypeId.UINT.name):
+        idc.create_word(symbol_ea)
+    elif (type.id == tdinfo_structs.TypeId.SLONG.name or
+          type.id == tdinfo_structs.TypeId.ULONG.name or
+          type.id == tdinfo_structs.TypeId.FAR.name):
+        idc.create_dword(symbol_ea)
+    elif type.id == tdinfo_structs.TypeId.ARRAY.name:
+        member = parsed_exe_file.type_records[type.member_type - 1]
+        if member.id == tdinfo_structs.TypeId.ARRAY.name: # array of arrays
+            idc.make_array(symbol_ea, type.size)
+        else:
+            _apply_tdinfo_type_rec(symbol_ea, symbol_name, parsed_exe_file, member)
+            idc.make_array(symbol_ea, type.size // member.size)
+    elif type.id == tdinfo_structs.TypeId.STRUCT.name:
+        struct_name = 'struct' + symbol_name
+        if get_struc_id(struct_name) == BADADDR: #check if struct already exists
+            _apply_tdinfo_struct(struct_name, parsed_exe_file, type)
+        idc.create_struct(symbol_ea, -1, struct_name)
+
+
+def _apply_tdinfo_struct(struct_name, parsed_exe_file, type): #create struct + members
+    id = idc.add_struc(-1, struct_name, 0)
+
+    memberIndex = type.member_type - 1
+    member = parsed_exe_file.member_records[memberIndex]
+    while True: # loop on struct members
+        member_name = str(parsed_exe_file.name_pool[member.name - 1])
+        member_type = parsed_exe_file.type_records[member.type - 1]
+
+        if (member_type.id == tdinfo_structs.TypeId.SINT.name or
+            member_type.id == tdinfo_structs.TypeId.UINT.name):
+            flag = FF_WORD
+        elif (member_type.id == tdinfo_structs.TypeId.SLONG.name or
+              member_type.id == tdinfo_structs.TypeId.ULONG.name or
+              member_type.id == tdinfo_structs.TypeId.FAR.name):
+            flag = FF_DWORD
+        else:
+            flag = FF_BYTE
+
+        idc.add_struc_member(id, member_name, -1, flag, -1, member_type.size)
+
+        memberIndex += 1
+        member = parsed_exe_file.member_records[memberIndex]
+        if member.info == 0xC0: #end marker
+            break
+
+
+def _apply_tdinfo_segment(image_base, parsed_exe_file, segment):
+    segment_ea = image_base + segment.code_segment * 0x10 + segment.code_offset
+    module = parsed_exe_file.module_records[segment.module - 1]
+    module_name = str(parsed_exe_file.name_pool[module.name - 1])
+
+    if set_segm_name(segment_ea, module_name):
+        print('Applied name {} to segment {:04X}:{:04X}'.format(
+            module_name,
+            image_base // 0x10 + segment.code_segment, segment.code_offset))
+
+
+def _apply_tdinfo_scopes(image_base, parsed_exe_file, segment):
+    for i in range(segment.scope_count):
+        scope = parsed_exe_file.scope_records[segment.scope_index - 1 + i]
+        _apply_tdinfo_scope(image_base, parsed_exe_file, segment, scope)
+
+
+def _apply_tdinfo_scope(image_base, parsed_exe_file, segment, scope):
+    scope_offset = scope.offset if scope.parent == 0 else parsed_exe_file.scope_records[scope.parent - 1].offset
+    scope_ea = image_base + segment.code_segment * 0x10 + scope_offset
+
+    for i in range(scope.symbol_count):
+        symbol = parsed_exe_file.symbol_records[scope.symbol_index - 1 + i]
+        _apply_tdinfo_localvar(image_base, parsed_exe_file, symbol, segment, scope_ea, scope_offset)
+
+
+def _apply_tdinfo_localvar(image_base, parsed_exe_file, symbol, segment, scope_ea, scope_offset):
+    if symbol.bitfield.symbol_class != tdinfo_structs.SymbolClass.AUTO.name:
+        return
+
+    symbol_name = str(parsed_exe_file.name_pool[symbol.index - 1])
+    offset = symbol.offset - 0x10000 if symbol.offset > 0x7fff else symbol.offset
+    operator = '+' if offset >= 0 else '-'
+
+    idc.add_func(scope_ea, BADADDR) # create function if needed
+    if (idc.define_local_var(scope_ea, scope_ea, '[bp{}{}]'.format(operator, abs(offset)), symbol_name)):
+        print('Applied name {} to [bp{}{}] at address {:04X}:{:04X}'.format(
+            symbol_name,
+            operator, abs(offset),
+            image_base // 0x10 + segment.code_segment, scope_offset))

--- a/tdinfo_structs.py
+++ b/tdinfo_structs.py
@@ -30,6 +30,53 @@ class SymbolClass(enum.IntEnum):
     STRUCT_UNION_OR_ENUM = 7
 
 
+class TypeId(enum.IntEnum):
+    VOID = 0
+    LSTR = 1
+    DSTR = 2
+    PSTR = 3
+    SCHAR = 4
+    SINT = 5
+    SLONG = 6
+    UCHAR = 8
+    UINT = 9
+    ULONG = 10
+    PCHAR = 12
+    FLOAT = 13
+    TPREAL = 14
+    DOUBLE = 15
+    LDOUBLE = 16
+    BCD4 = 17
+    BCD8 = 18
+    BCD10 = 19
+    BCDCOB = 20
+    NEAR = 21
+    FAR = 22
+    SEG = 23
+    NEAR386 = 24
+    FAR386 = 25
+    ARRAY = 26
+    PARRAY = 28
+    STRUCT = 30
+    UNION = 31
+    ENUM = 34
+    FUNCTION = 35
+    LABEL = 36
+    SET = 37
+    TFILE = 38
+    BFILE = 39
+    BOOL = 40
+    PENUM = 41
+    FUNCPROTOTYPE = 44
+    SPECIALFUNC = 45
+    OBJECT = 46
+    NREF = 52
+    FREF = 53
+    WORDBOOL = 54
+    LONGBOOL = 55
+    GLOBALHANDLE = 62
+    LOCALHANDLE = 63
+
 SYMBOL_RECORD_STRUCT = Struct(
     'index' / Int16ul,  # 1-based
     'type' / Int16ul,
@@ -38,6 +85,44 @@ SYMBOL_RECORD_STRUCT = Struct(
     'bitfield' / BitStruct(
         Padding(5),
         'symbol_class' / Enum(BitsInteger(3), SymbolClass))
+)
+
+TYPE_RECORD_STRUCT = Struct(
+    'id' / Enum(Byte, TypeId),
+    'name' / Int16ul,
+    'size' / Int16ul,
+    'class_type' / Byte,
+    'member_type' / Int16ul
+)
+
+MEMBER_RECORD_STRUCT = Struct(
+    'info' / Byte,
+    'name' / Int16ul,
+    'type' / Int16ul
+)
+
+MODULE_RECORD_STRUCT = Struct(
+    'name' / Int16ul,
+    Padding(14)
+)
+
+SEGMENT_RECORD_STRUCT = Struct(
+    'module' / Int16ul,
+    'code_segment' / Int16ul,
+    'code_offset' / Int16ul,
+    'code_length' / Int16ul,
+    'scope_index' / Int16ul,
+    'scope_count' / Int16ul,
+    Padding(4)
+)
+
+SCOPE_RECORD_STRUCT = Struct(
+    'symbol_index' / Int16ul,
+    'symbol_count' / Int16ul,
+    'parent' / Int16ul,
+    'function' / Int16ul,
+    'offset' / Int16ul,
+    'length' / Int16ul
 )
 
 TDINFO_HEADER_STRUCT = Struct(
@@ -50,7 +135,14 @@ TDINFO_HEADER_STRUCT = Struct(
     'members_count' / Int16ul,
     'symbols_count' / Int16ul,
     'globals_count' / Int16ul,
-    Padding(28),
+    'modules_count' / Int16ul,
+    'locals_count' / Int16ul,
+    'scopes_count' / Int16ul,
+    'linenumbers_count' / Int16ul,
+    'sourcefiles_count' / Int16ul,
+    'segments_count' / Int16ul,
+    'correlations_count' / Int16ul,
+    Padding(14),
     'extension_size' / Int16ul,
     Padding(this.extension_size)
 )
@@ -63,6 +155,14 @@ DOS_MZ_EXE_STRUCT = Struct(
     Padding(lambda ctx: calculate_extra_information_offset(ctx) - ctx.offset_of_unused_bytes),
     'tdinfo_header' / TDINFO_HEADER_STRUCT,
     'symbol_records' / SYMBOL_RECORD_STRUCT[this.tdinfo_header.symbols_count],
+    'module_records' / MODULE_RECORD_STRUCT[this.tdinfo_header.modules_count],
+    Padding(this.tdinfo_header.sourcefiles_count * 6),
+    Padding(this.tdinfo_header.linenumbers_count * 4),
+    'scope_records' / SCOPE_RECORD_STRUCT[this.tdinfo_header.scopes_count],
+    'segment_records' / SEGMENT_RECORD_STRUCT[this.tdinfo_header.segments_count],
+    Padding(this.tdinfo_header.correlations_count * 8),
+    'type_records' / TYPE_RECORD_STRUCT[this.tdinfo_header.types_count],
+    'member_records' / MEMBER_RECORD_STRUCT[this.tdinfo_header.members_count],
     Seek(-this.tdinfo_header.names_pool_size_in_bytes, whence=CONSTRUCT_SEEK_EOF),
     'name_pool' / CString('ascii')[this.tdinfo_header.names_count],
 )


### PR DESCRIPTION
What has been added : 
### Types
The following types are set on symbols when possible:

- char, unsigned char, int, unsigned int, long, unsigned long
- far 
- array 
- struct and members

### Segments
They are renamed based on related module name (which is based on C source filename)
Eg: "seg002" will be renamed to "SYSTEM" because it's defined in SYSTEM.C

### Scopes
local variables and function parameters are renamed when possible.
Eg: "arg_2" will be renamed "counter"

### Notes
- If needed, I can make some changes / suggestion to the code before merge.
- Best results are achieved by creating a new disassembly with auto-analysis turned off, then run python script and only later run analysis.
Otherwise IDA might recognise some symbols incorrectly (eg: "somevar1 dw, somevar2 dw" instead of "somevar dd").
- Function to call is still "apply_tdinfo_symbols" while it's actually doing more than that.
Maybe it should be renamed (eg: "apply_tdinfo"), or to provide several functions (eg: "apply_tdinfo_scopes"), depending what user want to achieve.
